### PR TITLE
writestr support data in str as underline function does

### DIFF
--- a/updateable_zip_file/__init__.py
+++ b/updateable_zip_file/__init__.py
@@ -36,6 +36,8 @@ class UpdateableZipFile(ZipFile):
             temp_file = self._replace[name] = self._replace.get(
                 name, tempfile.TemporaryFile()
             )
+            if isinstance(bytes, str):
+                bytes = bytes.encode("utf-8")
             temp_file.write(bytes)
         # Otherwise just act normally
         else:


### PR DESCRIPTION
I noticed that zipfile.writestr supports data being bytes or str, but UpdateableZipFile.writestr does not fully support it
This should do the trick.